### PR TITLE
refactor: modularise portfolio and streamline app

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,24 @@ One final shameless plug: (https://substack.com/@nathanbsmith?utm_source=edit-pr
 
 Find a mistake in the logs or have advice?
 Please Reach out here: nathanbsmith.business@gmail.com
+
+## Streamlit Dashboard
+
+This repository now ships with a lightweight Streamlit dashboard for managing
+the experimental portfolio locally.
+
+### Installation
+
+```
+pip install -r requirements.txt
+```
+
+### Running the App
+
+```
+streamlit run app.py
+```
+
+The application stores data in the `data/` directory so it survives across
+restarts.  If you encounter issues, ensure this folder is writable and that the
+CSV files are not open in another program.

--- a/portfolio.py
+++ b/portfolio.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Portfolio schema and helpers
+# ---------------------------------------------------------------------------
+
+PORTFOLIO_COLUMNS: List[str] = [
+    "ticker",
+    "shares",
+    "stop_loss",
+    "buy_price",
+    "cost_basis",
+]
+
+
+@dataclass
+class PortfolioRecord:
+    """Dataclass representing a single portfolio holding."""
+
+    ticker: str
+    shares: float
+    stop_loss: float
+    buy_price: float
+    cost_basis: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.cost_basis = self.shares * self.buy_price
+
+
+def ensure_schema(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with all expected portfolio columns present."""
+
+    for col in PORTFOLIO_COLUMNS:
+        if col not in df.columns:
+            df[col] = 0.0 if col != "ticker" else ""
+    return df[PORTFOLIO_COLUMNS].copy()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from portfolio import ensure_schema, PORTFOLIO_COLUMNS
+
+
+def test_ensure_schema_adds_missing_columns():
+    df = pd.DataFrame({"ticker": ["ABC"], "shares": [10]})
+    result = ensure_schema(df)
+    assert list(result.columns) == PORTFOLIO_COLUMNS
+    # Missing numeric columns should default to 0
+    assert result.loc[0, "stop_loss"] == 0


### PR DESCRIPTION
## Summary
- centralize file paths and constants in `app.py` and cache price lookups
- add `portfolio.py` with schema helpers and unit test
- enhance buy form with auto price & percent stop-loss; add downloads and error log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892723af8a88321ab56f291e026259f