### PR TITLE
Batch fetch ticker prices

### DIFF
--- a/services/market.py
+++ b/services/market.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import yfinance as yf
 import streamlit as st
 
@@ -14,6 +15,20 @@ def fetch_price(ticker: str) -> float | None:
     except Exception:
         log_error(f"Failed to fetch price for {ticker}")
         return None
+
+
+@st.cache_data(ttl=300)
+def fetch_prices(tickers: list[str]) -> pd.DataFrame:
+    """Return daily data for ``tickers`` in a single request."""
+
+    if not tickers:
+        return pd.DataFrame()
+
+    try:  # pragma: no cover - network errors
+        return yf.download(tickers, period="1d", progress=False)
+    except Exception:
+        log_error(f"Failed to fetch prices for {', '.join(tickers)}")
+        return pd.DataFrame()
 
 
 def get_day_high_low(ticker: str) -> tuple[float, float]:


### PR DESCRIPTION
## Summary
- Add `fetch_prices` to pull multiple tickers in one request with caching.
- Update portfolio snapshot and watchlist refresh to parse batch price data.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893568bd6f883218a1b12a726d927d2