### PR TITLE
Load theme from config and remove runtime switch

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,14 @@
+[theme]
+base = "light"
+
+[theme.light]
+primaryColor = "#2A9D8F"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F0F2F6"
+textColor = "#000000"
+
+[theme.dark]
+primaryColor = "#2A9D8F"
+backgroundColor = "#0E1117"
+secondaryBackgroundColor = "#262730"
+textColor = "#FAFAFA"

--- a/app.py
+++ b/app.py
@@ -1,11 +1,15 @@
 """Streamlit app for local portfolio tracking and AI‑assisted trading."""
 
 import streamlit as st
+from streamlit import config as _config
 
 from ui.dashboard import render_dashboard
 from ui.user_guide import render_user_guide
 
-st.set_page_config(page_title="AI Assisted Trading")
+st.set_page_config(
+    page_title="AI Assisted Trading",
+    theme=_config.get_option("theme.base"),
+)
 
 
 def main() -> None:

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -41,13 +41,6 @@ def render_dashboard() -> None:
     show_watchlist_sidebar()
     show_onboarding()
 
-    theme = st.sidebar.radio("Theme", ["Light", "Dark"], key="theme")
-    if theme == "Dark":
-        st.write(
-            "<style>body { background-color: #0e1117; color: white; }</style>",
-            unsafe_allow_html=True,
-        )
-
     feedback = st.session_state.pop("feedback", None)
     if feedback:
         kind, text = feedback


### PR DESCRIPTION
## Summary
- define light and dark color palettes in `.streamlit/config.toml`
- remove dashboard theme selector and custom CSS
- configure `st.set_page_config` to pick theme from configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935878060c83218787962eb2930319