### PR TITLE
Validate positive trade inputs

### DIFF
--- a/services/trading.py
+++ b/services/trading.py
@@ -36,6 +36,10 @@ def manual_buy(
     """Execute a manual buy and update portfolio and logs."""
 
     ticker = ticker.upper()
+    if shares <= 0 or price <= 0:
+        msg = "Shares and price must be positive."
+        log_error(msg)
+        return False, msg, portfolio_df, cash
     try:
         day_high, day_low = get_day_high_low(ticker)
     except Exception as exc:  # pragma: no cover - network errors
@@ -102,6 +106,10 @@ def manual_sell(
     """Execute a manual sell and update portfolio and logs."""
 
     ticker = ticker.upper()
+    if shares <= 0 or price <= 0:
+        msg = "Shares and price must be positive."
+        log_error(msg)
+        return False, msg, portfolio_df, cash
     if ticker not in portfolio_df[COL_TICKER].values:
         msg = "Ticker not in portfolio."
         log_error(msg)

--- a/tests/test_trading_validation.py
+++ b/tests/test_trading_validation.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from config import COL_TICKER, COL_SHARES, COL_STOP, COL_PRICE, COL_COST
+from services import trading
+
+
+def _empty_portfolio():
+    return pd.DataFrame(columns=[COL_TICKER, COL_SHARES, COL_STOP, COL_PRICE, COL_COST])
+
+
+def test_manual_buy_rejects_non_positive_values():
+    df = _empty_portfolio()
+    ok, msg, *_ = trading.manual_buy("ABC", 0, 10, 0, df, 1000)
+    assert not ok
+    assert "positive" in msg
+    ok, msg, *_ = trading.manual_buy("ABC", 1, 0, 0, df, 1000)
+    assert not ok
+    assert "positive" in msg
+
+
+def test_manual_sell_rejects_non_positive_values():
+    df = pd.DataFrame(
+        [{COL_TICKER: "ABC", COL_SHARES: 10, COL_STOP: 0, COL_PRICE: 5, COL_COST: 50}]
+    )
+    ok, msg, *_ = trading.manual_sell("ABC", 0, 10, df, 0)
+    assert not ok
+    assert "positive" in msg
+    ok, msg, *_ = trading.manual_sell("ABC", 1, 0, df, 0)
+    assert not ok
+    assert "positive" in msg

--- a/ui/forms.py
+++ b/ui/forms.py
@@ -9,6 +9,12 @@ def show_buy_form() -> None:
     """Render and process the buy form inside an expander."""
 
     def submit_buy() -> None:
+        if st.session_state.b_shares <= 0 or st.session_state.b_price <= 0:
+            st.session_state.feedback = (
+                "error",
+                "Shares and price must be positive.",
+            )
+            return
         ok, msg, port, cash = manual_buy(
             st.session_state.b_ticker,
             st.session_state.b_shares,
@@ -33,10 +39,10 @@ def show_buy_form() -> None:
     with st.expander("Log a Buy"):
         with st.form("buy_form", clear_on_submit=True):
             ticker = st.text_input("Ticker", key="b_ticker")
-            st.number_input("Shares", min_value=0.0, step=1.0, key="b_shares")
+            st.number_input("Shares", min_value=1, step=1, key="b_shares")
             latest = fetch_price(ticker) if ticker else 0.0
             st.number_input(
-                "Price", min_value=0.0, format="%.2f", key="b_price", value=latest or 0.0
+                "Price", min_value=1.0, step=0.01, format="%.2f", key="b_price", value=latest or 1.0
             )
             st.number_input(
                 "Stop Loss %", min_value=0.0, format="%.1f", key="b_stop_pct"
@@ -52,6 +58,12 @@ def show_sell_form() -> None:
     """Render and process the sell form inside an expander."""
 
     def submit_sell() -> None:
+        if st.session_state.s_shares <= 0 or st.session_state.s_price <= 0:
+            st.session_state.feedback = (
+                "error",
+                "Shares and price must be positive.",
+            )
+            return
         ok, msg, port, cash = manual_sell(
             st.session_state.s_ticker,
             st.session_state.s_shares,
@@ -73,7 +85,7 @@ def show_sell_form() -> None:
         with st.form("sell_form", clear_on_submit=True):
             tickers = st.session_state.portfolio[COL_TICKER].tolist()
             st.selectbox("Ticker", tickers, key="s_ticker")
-            st.number_input("Shares", min_value=0.0, step=1.0, key="s_shares")
-            st.number_input("Price", min_value=0.0, format="%.2f", key="s_price")
+            st.number_input("Shares", min_value=1, step=1, key="s_shares")
+            st.number_input("Price", min_value=1.0, step=0.01, format="%.2f", key="s_price")
             st.form_submit_button("Submit Sell", on_click=submit_sell)
 


### PR DESCRIPTION
## Summary
- Enforce positive shares and price in buy/sell forms with appropriate step sizes.
- Add validation to trading services to reject non-positive share or price values.
- Test manual buy and sell for invalid input scenarios.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68935b2c2b008321a5698df54b685a07