### PR TITLE
Fix onboarding info dismiss button rerun

### DIFF
--- a/services/session.py
+++ b/services/session.py
@@ -23,6 +23,7 @@ def init_session_state() -> None:
         "watchlist_prices": {},
         "show_cash_form": False,
         "daily_summary": "",
+        "show_info": True,
     }.items():
         st.session_state.setdefault(key, default)
 

--- a/ui/onboarding.py
+++ b/ui/onboarding.py
@@ -4,19 +4,15 @@ import streamlit as st
 def show_onboarding() -> None:
     """Display a simple onboarding message for first-time users."""
 
-    if not st.session_state.get("dismissed_onboarding"):
-        def dismiss() -> None:
-            st.session_state.dismissed_onboarding = True
-            st.rerun()
-
+    if st.session_state.get("show_info", True):
         st.info(
             "Use the controls below to manage your portfolio. Data is stored in the local `data/` directory."
         )
-        st.button("Dismiss", key="dismiss_onboard", on_click=dismiss)
+        if st.button("Dismiss", key="dismiss_onboard"):
+            st.session_state.show_info = False
 
 
 def dismiss_summary() -> None:
-    """Hide the daily summary and immediately rerun the app."""
+    """Hide the daily summary."""
 
     st.session_state.daily_summary = ""
-    st.rerun()


### PR DESCRIPTION
## Summary
- Remove `st.rerun()` from onboarding dismiss callbacks and rely on session state for rerun
- Initialize `show_info` in session state so info box renders once and dismisses cleanly
- Simplify daily summary dismissal to update state without extra rerun

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893638754d8832191990a157ae5edfa