### PR TITLE
Fix dismiss button behavior and replace invalid emoji

### DIFF
--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -6,7 +6,7 @@ from config import TRADE_LOG_CSV
 from data.portfolio import save_portfolio_snapshot
 from services.session import init_session_state
 from ui.watchlist import show_watchlist_sidebar
-from ui.onboarding import show_onboarding, dismiss_summary
+from ui.onboarding import show_onboarding
 from ui.cash import show_cash_section
 from ui.forms import show_buy_form, show_sell_form
 from ui.summary import build_daily_summary
@@ -223,7 +223,11 @@ def render_dashboard() -> None:
                 st.info("No summary available.")
         if st.session_state.get("daily_summary"):
             st.code(st.session_state.daily_summary, language="markdown")
-            st.button("Dismiss Summary", key="dismiss_summary", on_click=dismiss_summary)
+            st.button(
+                "Dismiss Summary",
+                key="dismiss_summary",
+                on_click=lambda: st.session_state.update(daily_summary=""),
+            )
 
         if st.session_state.get("error_log"):
             st.subheader("Error Log")

--- a/ui/onboarding.py
+++ b/ui/onboarding.py
@@ -8,11 +8,8 @@ def show_onboarding() -> None:
         st.info(
             "Use the controls below to manage your portfolio. Data is stored in the local `data/` directory."
         )
-        if st.button("Dismiss", key="dismiss_onboard"):
-            st.session_state.show_info = False
-
-
-def dismiss_summary() -> None:
-    """Hide the daily summary."""
-
-    st.session_state.daily_summary = ""
+        st.button(
+            "Dismiss",
+            on_click=lambda: st.session_state.update(show_info=False),
+            key="dismiss_onboard",
+        )

--- a/ui/watchlist.py
+++ b/ui/watchlist.py
@@ -70,7 +70,7 @@ def show_watchlist_sidebar() -> None:
         header = sidebar.container()
         hcol1, hcol2 = header.columns([4, 1])
         hcol1.subheader("Watchlist")
-        if hcol2.button("\ud83d\udd04", key="refresh_watchlist", help="Refresh prices"):
+        if hcol2.button("🔄", key="refresh_watchlist", help="Refresh prices"):
             data = fetch_prices(st.session_state.watchlist)
             updated: dict[str, float | None] = {t: None for t in st.session_state.watchlist}
             if not data.empty:


### PR DESCRIPTION
## Summary
- Use Streamlit `on_click` callbacks for onboarding and summary dismissal buttons to hide banners in one click
- Replace surrogate pair refresh icon with Unicode emoji to avoid UTF-8 encoding crash

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689365de21b48321bb62904cf9d6c64b