### PR TITLE
Ensure form defaults satisfy min values

### DIFF
--- a/services/session.py
+++ b/services/session.py
@@ -10,12 +10,12 @@ def init_session_state() -> None:
 
     for key, default in {
         "b_ticker": "",
-        "b_shares": 0.0,
-        "b_price": 0.0,
+        "b_shares": 1.0,
+        "b_price": 1.0,
         "b_stop_pct": 0.0,
         "s_ticker": "",
-        "s_shares": 0.0,
-        "s_price": 0.0,
+        "s_shares": 1.0,
+        "s_price": 1.0,
         "ac_amount": 0.0,
         "lookup_symbol": "",
         "watchlist_feedback": None,

--- a/ui/forms.py
+++ b/ui/forms.py
@@ -30,8 +30,8 @@ def show_buy_form() -> None:
             st.session_state.cash = cash
             st.session_state.feedback = ("success", msg)
             st.session_state.b_ticker = ""
-            st.session_state.b_shares = 0.0
-            st.session_state.b_price = 0.0
+            st.session_state.b_shares = 1.0
+            st.session_state.b_price = 1.0
             st.session_state.b_stop_pct = 0.0
         else:
             st.session_state.feedback = ("error", msg)
@@ -76,8 +76,8 @@ def show_sell_form() -> None:
             st.session_state.cash = cash
             st.session_state.feedback = ("success", msg)
             st.session_state.s_ticker = ""
-            st.session_state.s_shares = 0.0
-            st.session_state.s_price = 0.0
+            st.session_state.s_shares = 1.0
+            st.session_state.s_price = 1.0
         else:
             st.session_state.feedback = ("error", msg)
 


### PR DESCRIPTION
## Summary
- Align session-state defaults for buy/sell shares and prices with widget minimums
- Reset share and price fields to valid defaults after submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68937c6ccb1483218b253657f0358dc5