### PR TITLE
Add reusable top navigation bar

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,22 +1,24 @@
 """Streamlit app for local portfolio tracking and AI‑assisted trading."""
 
+from pathlib import Path
+
 import streamlit as st
 from streamlit import config as _config
 
+from components.nav import navbar
 from ui.dashboard import render_dashboard
 from ui.user_guide import render_user_guide
 
 st.set_page_config(
     page_title="AI Assisted Trading",
-    page_icon="🚀",           # optional, if you want an icon
-    layout="wide",           # optional, choose your layout
-    initial_sidebar_state="expanded"  # optional
+    page_icon="🚀",  # optional, if you want an icon
+    layout="wide",  # optional, choose your layout
+    initial_sidebar_state="collapsed",  # hide the sidebar navigation
 )
 
+navbar(Path(__file__).name)
+
 st.title("📊 Portfolio Dashboard")
-with st.container():
-    st.page_link("app.py", label="📊 Portfolio", icon="📊")
-    st.page_link("pages/02_Performance.py", label="📈 Performance", icon="📈")
 
 
 def main() -> None:

--- a/components/nav.py
+++ b/components/nav.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import streamlit as st
+
+
+def navbar(active_page: str) -> None:
+    """Render top navigation bar and hide sidebar navigation.
+
+    Parameters
+    ----------
+    active_page: str
+        The filename of the current page. Used to style the active link.
+    """
+    st.markdown(
+        """
+        <style>
+            [data-testid="stSidebarNav"] {display: none;}
+            div[data-testid="stColumn"] > div > a[data-testid="stPageLink"] {
+                text-decoration: none;
+                color: inherit;
+                padding-right: 1rem;
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    nav = st.container()
+    with nav:
+        col1, col2 = st.columns(2)
+        if Path("app.py").name == active_page:
+            col1.markdown(
+                "<span style='font-weight:bold; color:red;'>Portfolio</span>",
+                unsafe_allow_html=True,
+            )
+        else:
+            col1.page_link("app.py", label="Portfolio")
+
+        if Path("pages/02_Performance.py").name == active_page:
+            col2.markdown(
+                "<span style='font-weight:bold; color:red;'>Performance</span>",
+                unsafe_allow_html=True,
+            )
+        else:
+            col2.page_link("pages/02_Performance.py", label="Performance")
+    nav.markdown("<hr />", unsafe_allow_html=True)

--- a/pages/02_Performance.py
+++ b/pages/02_Performance.py
@@ -6,12 +6,14 @@ import pandas as pd
 import streamlit as st
 import yfinance as yf
 
+from components.nav import navbar
 
-st.set_page_config(page_title="Performance", layout="wide")
+
+st.set_page_config(page_title="Performance", layout="wide", initial_sidebar_state="collapsed")
+
+navbar(Path(__file__).name)
+
 st.title("📈 Performance Dashboard")
-with st.container():
-    st.page_link("app.py", label="📊 Portfolio", icon="📊")
-    st.page_link("pages/02_Performance.py", label="📈 Performance", icon="📈")
 
 
 @st.cache_data


### PR DESCRIPTION
## Summary
- replace page-link sidebar navigation with a reusable top nav bar
- collapse and hide sidebar navigation across pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ae5419a883219dc2b0426f02b83d