### PR TITLE
feat: add top navigation bar

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ st.set_page_config(
     page_title="AI Assisted Trading",
     page_icon="🚀",  # optional, if you want an icon
     layout="wide",  # optional, choose your layout
-    initial_sidebar_state="collapsed",  # hide the sidebar navigation
+    initial_sidebar_state="expanded",  # keep the sidebar visible on load
 )
 
 navbar(Path(__file__).name)

--- a/components/nav.py
+++ b/components/nav.py
@@ -1,23 +1,40 @@
+"""Navigation bar component used across pages."""
+
 from pathlib import Path
+
 import streamlit as st
 
 
 def navbar(active_page: str) -> None:
-    """Render top navigation bar and hide sidebar navigation.
+    """Render a horizontal navigation bar and hide default sidebar links.
 
     Parameters
     ----------
-    active_page: str
-        The filename of the current page. Used to style the active link.
+    active_page:
+        Name of the current file (e.g. ``Path(__file__).name``).
     """
+
     st.markdown(
         """
         <style>
             [data-testid="stSidebarNav"] {display: none;}
-            div[data-testid="stColumn"] > div > a[data-testid="stPageLink"] {
+            .nav-container {
+                display: flex;
+                gap: 2rem;
+                padding-bottom: 0.25rem;
+            }
+            .nav-link {
                 text-decoration: none;
                 color: inherit;
-                padding-right: 1rem;
+                border-bottom: 3px solid transparent;
+                padding-bottom: 0.25rem;
+            }
+            .nav-link:hover {
+                border-bottom: 3px solid #999999;
+            }
+            .nav-link.active {
+                font-weight: bold;
+                border-bottom: 3px solid red;
             }
         </style>
         """,
@@ -26,20 +43,15 @@ def navbar(active_page: str) -> None:
 
     nav = st.container()
     with nav:
-        col1, col2 = st.columns(2)
-        if Path("app.py").name == active_page:
-            col1.markdown(
-                "<span style='font-weight:bold; color:red;'>Portfolio</span>",
-                unsafe_allow_html=True,
-            )
-        else:
-            col1.page_link("app.py", label="Portfolio")
+        st.markdown(
+            f"""
+            <div class="nav-container">
+                <a class="nav-link {'active' if active_page == Path('app.py').name else ''}" href="/" target="_self">Portfolio</a>
+                <a class="nav-link {'active' if active_page == Path('pages/02_Performance.py').name else ''}" href="/Performance" target="_self">Performance</a>
+            </div>
+            <hr />
+            """,
+            unsafe_allow_html=True,
+        )
 
-        if Path("pages/02_Performance.py").name == active_page:
-            col2.markdown(
-                "<span style='font-weight:bold; color:red;'>Performance</span>",
-                unsafe_allow_html=True,
-            )
-        else:
-            col2.page_link("pages/02_Performance.py", label="Performance")
-    nav.markdown("<hr />", unsafe_allow_html=True)
+

--- a/pages/02_Performance.py
+++ b/pages/02_Performance.py
@@ -9,7 +9,7 @@ import yfinance as yf
 from components.nav import navbar
 
 
-st.set_page_config(page_title="Performance", layout="wide", initial_sidebar_state="collapsed")
+st.set_page_config(page_title="Performance", layout="wide", initial_sidebar_state="expanded")
 
 navbar(Path(__file__).name)
 


### PR DESCRIPTION
## Summary
- add reusable top navigation bar with Portfolio and Performance tabs
- open sidebar by default on each page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b222c4b08321b96c4669f9b78721