### PR TITLE
Refine Streamlit header and navigation layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,28 +7,22 @@ from streamlit import config as _config
 
 from components.nav import navbar
 from ui.dashboard import render_dashboard
-from ui.user_guide import render_user_guide
 
 st.set_page_config(
     page_title="AI Assisted Trading",
-    page_icon="🚀",  # optional, if you want an icon
-    layout="wide",  # optional, choose your layout
-    initial_sidebar_state="expanded",  # keep the sidebar visible on load
+    layout="wide",
+    initial_sidebar_state="expanded",
 )
 
 navbar(Path(__file__).name)
 
-st.title("📊 Portfolio Dashboard")
+st.header("Portfolio Dashboard")
 
 
 def main() -> None:
     """Application entry point."""
 
-    dashboard_tab, guide_tab = st.tabs(["Dashboard", "User Guide"])
-    with dashboard_tab:
-        render_dashboard()
-    with guide_tab:
-        render_user_guide()
+    render_dashboard()
 
 
 if __name__ == "__main__":

--- a/components/nav.py
+++ b/components/nav.py
@@ -1,18 +1,23 @@
 """Navigation bar component used across pages."""
 
 from pathlib import Path
+import base64
 
 import streamlit as st
 
+from services.session import init_session_state
+
 
 def navbar(active_page: str) -> None:
-    """Render a horizontal navigation bar and hide default sidebar links.
+    """Render the application title and horizontal navigation bar.
 
     Parameters
     ----------
     active_page:
         Name of the current file (e.g. ``Path(__file__).name``).
     """
+
+    init_session_state()
 
     st.markdown(
         """
@@ -41,13 +46,25 @@ def navbar(active_page: str) -> None:
         unsafe_allow_html=True,
     )
 
+    st.title("AI Assisted Trading")
+
     nav = st.container()
     with nav:
+        csv_link = ""
+        if not st.session_state.portfolio.empty:
+            csv = st.session_state.portfolio.to_csv(index=False).encode("utf-8")
+            b64 = base64.b64encode(csv).decode()
+            csv_link = f"<a class='nav-link' href='data:text/csv;base64,{b64}' download='portfolio_snapshot.csv'>Download Portfolio</a>"
+        else:
+            csv_link = "<span class='nav-link'>Download Portfolio</span>"
+
         st.markdown(
             f"""
             <div class="nav-container">
-                <a class="nav-link {'active' if active_page == Path('app.py').name else ''}" href="/" target="_self">Portfolio</a>
+                <a class="nav-link {'active' if active_page == Path('app.py').name else ''}" href="/" target="_self">Dashboard</a>
                 <a class="nav-link {'active' if active_page == Path('pages/02_Performance.py').name else ''}" href="/Performance" target="_self">Performance</a>
+                <a class="nav-link {'active' if active_page == Path('pages/03_UserGuide.py').name else ''}" href="/UserGuide" target="_self">User Guide</a>
+                {csv_link}
             </div>
             <hr />
             """,

--- a/pages/02_Performance.py
+++ b/pages/02_Performance.py
@@ -13,7 +13,7 @@ st.set_page_config(page_title="Performance", layout="wide", initial_sidebar_stat
 
 navbar(Path(__file__).name)
 
-st.title("📈 Performance Dashboard")
+st.header("Performance Dashboard")
 
 
 @st.cache_data

--- a/pages/03_UserGuide.py
+++ b/pages/03_UserGuide.py
@@ -1,0 +1,22 @@
+"""User guide page for the application."""
+
+from pathlib import Path
+
+import streamlit as st
+
+from components.nav import navbar
+from ui.user_guide import render_user_guide
+
+
+st.set_page_config(
+    page_title="User Guide",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+navbar(Path(__file__).name)
+
+st.header("User Guide")
+
+render_user_guide()
+

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import pandas as pd
 import streamlit as st
 
-from config import TRADE_LOG_CSV
 from data.portfolio import save_portfolio_snapshot
 from services.session import init_session_state
 from ui.watchlist import show_watchlist_sidebar
@@ -16,27 +15,6 @@ def render_dashboard() -> None:
     """Render the main dashboard tab."""
 
     init_session_state()
-
-    header_cols = st.columns([4, 1, 1])
-    header_cols[0].title("AI Assisted Trading")
-    if not st.session_state.portfolio.empty:
-        csv = st.session_state.portfolio.to_csv(index=False).encode("utf-8")
-        header_cols[1].download_button(
-            "Download Portfolio", csv, "portfolio_snapshot.csv", "text/csv"
-        )
-    else:
-        header_cols[1].empty()
-    if TRADE_LOG_CSV.exists():
-        tl_df = pd.read_csv(TRADE_LOG_CSV)
-        if not tl_df.empty:
-            tl_csv = tl_df.to_csv(index=False).encode("utf-8")
-            header_cols[2].download_button(
-                "Download Trade Log", tl_csv, "trade_log.csv", "text/csv"
-            )
-        else:
-            header_cols[2].empty()
-    else:
-        header_cols[2].empty()
 
     show_watchlist_sidebar()
     show_onboarding()

--- a/ui/user_guide.py
+++ b/ui/user_guide.py
@@ -2,7 +2,6 @@ import streamlit as st
 
 
 def render_user_guide() -> None:
-    st.header("User Guide")
     st.markdown(
         """
         ### Getting Started


### PR DESCRIPTION
## Summary
- Implement unified navigation component with app title, page links and portfolio download
- Clean up page hierarchy: each page shows main header after nav, tabs removed
- Add dedicated User Guide page for consistent multi-page navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e5a368b48321b097d914fdeb1197