### PR TITLE
Keep sidebar container visible

### DIFF
--- a/components/nav.py
+++ b/components/nav.py
@@ -22,7 +22,7 @@ def navbar(active_page: str) -> None:
     st.markdown(
         """
         <style>
-            [data-testid="stSidebarNav"] {display: none;}
+            [data-testid="stSidebarNav"] {visibility: hidden;}
             .nav-container {
                 display: flex;
                 gap: 2rem;


### PR DESCRIPTION
## Summary
- Preserve Streamlit sidebar container by swapping `display: none` with `visibility: hidden`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68940ba67b088321a2284079be75cc46