### PR TITLE
Clean up sidebar nav and sell form behavior

### DIFF
--- a/components/nav.py
+++ b/components/nav.py
@@ -22,7 +22,11 @@ def navbar(active_page: str) -> None:
     st.markdown(
         """
         <style>
-            
+
+            [data-testid="stSidebarNav"] {
+                display: none;
+            }
+
             .nav-container {
                 display: flex;
                 gap: 2rem;

--- a/ui/forms.py
+++ b/ui/forms.py
@@ -97,7 +97,12 @@ def show_sell_form() -> None:
         else:
             st.session_state.feedback = ("error", msg)
 
-    with st.expander("Log a Sell", expanded=True):
+    st.checkbox("Always show Sell form", key="show_sell")
+    expanded = not st.session_state.portfolio.empty and st.session_state.get(
+        "show_sell", False
+    )
+
+    with st.expander("Log a Sell", expanded=expanded):
         holdings = st.session_state.portfolio
         if holdings.empty:
             st.info("You have no holdings to sell.")

--- a/ui/watchlist.py
+++ b/ui/watchlist.py
@@ -11,6 +11,8 @@ def show_watchlist_sidebar() -> None:
     """Render ticker lookup and watchlist in the sidebar."""
 
     sidebar = st.sidebar
+    sidebar.caption("Watchlist Tool")
+    sidebar.divider()
     sidebar.header("Ticker Lookup")
     feedback_slot = sidebar.empty()
 
@@ -108,3 +110,4 @@ def show_watchlist_sidebar() -> None:
         kind, text = st.session_state.watchlist_feedback
         getattr(feedback_slot, kind)(text)
         st.session_state.watchlist_feedback = None
+    sidebar.divider()


### PR DESCRIPTION
## Summary
- Hide Streamlit's default sidebar page navigation in favor of the existing top navbar
- Label the sidebar watchlist tools and add dividers for clearer separation
- Collapse the "Log a Sell" form by default and add option to keep it open

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894157a40bc8321a6e0acba1a3f504e