### PR TITLE
Ensure watchlist accessible on all pages

### DIFF
--- a/pages/02_Performance.py
+++ b/pages/02_Performance.py
@@ -6,11 +6,14 @@ import pandas as pd
 import streamlit as st
 
 from components.nav import navbar
+from ui.watchlist import show_watchlist_sidebar
 
 
 st.set_page_config(page_title="Performance", layout="wide", initial_sidebar_state="expanded")
 
 navbar(Path(__file__).name)
+
+show_watchlist_sidebar()
 
 st.subheader("Performance Dashboard")
 

--- a/pages/03_UserGuide.py
+++ b/pages/03_UserGuide.py
@@ -6,6 +6,7 @@ import streamlit as st
 
 from components.nav import navbar
 from ui.user_guide import render_user_guide
+from ui.watchlist import show_watchlist_sidebar
 
 
 st.set_page_config(
@@ -15,6 +16,8 @@ st.set_page_config(
 )
 
 navbar(Path(__file__).name)
+
+show_watchlist_sidebar()
 
 st.header("User Guide")
 


### PR DESCRIPTION
## Summary
- expose watchlist sidebar on Performance and User Guide pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68941a3a945c8321aa4b2803adea0336