### PR TITLE
fix: clear watchlist input with form submission

### DIFF
--- a/ui/watchlist.py
+++ b/ui/watchlist.py
@@ -28,7 +28,6 @@ def show_watchlist_sidebar() -> None:
             st.session_state.watchlist_prices[sym] = price
             save_watchlist(st.session_state.watchlist)
             st.session_state.watchlist_feedback = ("success", f"{sym} added to watchlist.")
-        st.session_state.lookup_symbol = ""
 
     portfolio_tickers = (
         set(st.session_state.portfolio[COL_TICKER].values)


### PR DESCRIPTION
## Summary
- avoid session state mutations when adding watchlist symbols
- clear lookup field via form submission using `clear_on_submit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b1bae750832185d0d07432180697