### PR TITLE
Expose Log a Buy form with LogABuy alias

### DIFF
--- a/ui/forms.py
+++ b/ui/forms.py
@@ -154,3 +154,6 @@ def show_sell_form() -> None:
             st.form_submit_button("Submit Sell", on_click=submit_sell)
 
 
+LogABuy = show_buy_form
+
+


### PR DESCRIPTION
## Summary
- expose existing `show_buy_form` as `LogABuy` for import convenience

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d9bb34a88321bd92d513831e02e9