### PR TITLE
Import remove_from_watchlist for watchlist page

### DIFF
--- a/pages/watchlist.py
+++ b/pages/watchlist.py
@@ -6,7 +6,7 @@ import streamlit as st
 
 from components.nav import navbar
 from services.market import fetch_prices
-from services.session import get_watchlist, add_to_watchlist
+from services.session import get_watchlist, add_to_watchlist, remove_from_watchlist
 from ui.forms import LogABuy
 
 


### PR DESCRIPTION
## Summary
- import `remove_from_watchlist` alongside other session helpers in the watchlist page

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f7de5ee08321af7166cab84221a9