### PR TITLE
Import YFPricesMissingError in watchlist

### DIFF
--- a/pages/watchlist.py
+++ b/pages/watchlist.py
@@ -6,6 +6,7 @@ import streamlit as st
 
 from components.nav import navbar
 from services.market import fetch_prices
+from services.market import YFPricesMissingError
 from services.session import get_watchlist, add_to_watchlist, remove_from_watchlist
 from ui.forms import LogABuy
 


### PR DESCRIPTION
## Summary
- import `YFPricesMissingError` so the watchlist page can handle missing price data from the market service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894feff77a0832184e967931485fe07