### PR TITLE
chore: archive legacy scripts and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ So, starting with just $100, I wanted to answer a simple but powerful question:
 
 - [Prompts](https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment/blob/main/Experiment%20Details/Prompts.md)
 
-- [Starting Your Own](https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment/blob/main/Start%20Your%20Own/README.md)
+- [Archived "Start Your Own" examples](legacy/start_your_own/README.md)
 
 -  [Markdown Research Summaries (MD)](https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment/tree/main/Weekly%20Deep%20Research%20(MD))
 - [Weekly Deep Research Reports (PDF)](https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment/tree/main/Weekly%20Deep%20Research%20(PDF))
@@ -74,6 +74,13 @@ To run the scripts locally, install the Python dependencies:
 ```
 pip install -r requirements.txt
 ```
+
+# Supported Scripts
+
+- `trading_script.py` — core CLI for updating the portfolio and logging trades.
+- `scripts/generate_graph.py` — plot portfolio performance against the S&P 500.
+
+Historical wrapper scripts are kept in the `legacy/` folder for reference.
 
 # Follow Along
 The experiment runs June 2025 to December 2025.

--- a/legacy/start_your_own/Generate_Graph.py
+++ b/legacy/start_your_own/Generate_Graph.py
@@ -1,5 +1,8 @@
 """Plot ChatGPT portfolio performance against the S&P 500.
 
+Archived example script from early versions of the project. It is kept
+for reference and is no longer maintained.
+
 The script loads logged portfolio equity, fetches S&P 500 data, and
 renders a comparison chart. Core behaviour remains unchanged; the code
 is simply reorganised and commented for clarity.

--- a/legacy/start_your_own/README.md
+++ b/legacy/start_your_own/README.md
@@ -1,6 +1,7 @@
-# Start Your Own
+# Start Your Own (Archived)
 
-This folder lets you run the trading experiment on your own computer. It contains two small scripts and the CSV files they produce.
+These scripts are preserved for historical reference and are no longer maintained.
+The folder lets you run the trading experiment on your own computer. It contains two small scripts and the CSV files they produce.
 
 Run the commands below from the repository root. The scripts automatically
 save their CSV data inside this folder.

--- a/legacy/start_your_own/Trading_Script.py
+++ b/legacy/start_your_own/Trading_Script.py
@@ -1,6 +1,9 @@
 # Improved user prompts and guidance for manual trades and daily summaries
 # (2025-08-04 usability update)
-"""Wrapper for the shared trading script using local data directory."""
+"""Wrapper for the shared trading script using a local data directory.
+
+This example script is archived and kept for reference only.
+"""
 
 from pathlib import Path
 import sys

--- a/legacy/trading_script_wrapper.py
+++ b/legacy/trading_script_wrapper.py
@@ -1,4 +1,7 @@
-"""Wrapper for the shared trading script using local data directory."""
+"""Wrapper for the shared trading script using a legacy data directory.
+
+This file is retained for historical reference and is no longer maintained.
+"""
 
 from pathlib import Path
 import sys

--- a/scripts/generate_graph.py
+++ b/scripts/generate_graph.py
@@ -13,7 +13,8 @@ import pandas as pd
 import yfinance as yf
 from typing import cast
 
-DATA_DIR = Path(__file__).resolve().parent
+# Portfolio CSVs live at the repository root alongside ``trading_script.py``
+DATA_DIR = Path(__file__).resolve().parents[1]
 PORTFOLIO_CSV = DATA_DIR / "chatgpt_portfolio_update.csv"
 
 


### PR DESCRIPTION
## Summary
- Move old console scripts into a new `legacy/` folder for reference
- Relocate portfolio graph script to `scripts/` and point it at the repo root for data
- Clarify README with supported scripts and link to archived examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955c0988f88321bffa3c17fd8e9b77