### PR TITLE
refactor: use module-level Streamlit import

### DIFF
--- a/services/session.py
+++ b/services/session.py
@@ -64,5 +64,4 @@ def remove_from_watchlist(symbol: str) -> None:
         # Persist the updated list
         save_watchlist(watchlist)
         # Update session state if needed
-        import streamlit as st
         st.session_state.watchlist = watchlist


### PR DESCRIPTION
## Summary
- remove redundant inner `streamlit` import when updating the watchlist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956052d3d88321aff7cdbdc1679f91