### PR TITLE
Use batch price lookup for watchlist

### DIFF
--- a/pages/watchlist.py
+++ b/pages/watchlist.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from datetime import datetime
+import math
 
 import streamlit as st
 
@@ -22,19 +23,40 @@ st.markdown(
 
 from components.nav import navbar
 from services.session import get_watchlist, add_to_watchlist, remove_from_watchlist
-from services.market import fetch_price
+from services.market import fetch_price, fetch_prices
 from ui.forms import LogABuy
 
 
 @st.cache_data(ttl=1800)
-def load_watchlist_prices(tickers: list[str]) -> dict[str, dict]:
-    prices = {}
-    for t in tickers:
-        try:
-            prices[t] = fetch_price(t)
-        except Exception:
-            # skip invalid or missing tickers
-            continue
+def load_watchlist_prices(tickers: list[str]) -> dict[str, float]:
+    data = fetch_prices(tickers)
+    prices: dict[str, float] = {}
+    if data.empty:
+        return prices
+
+    if data.columns.nlevels > 1:
+        close = data["Close"].iloc[-1]
+        for t in tickers:
+            val = close.get(t)
+            if val is None:
+                continue
+            try:
+                price = float(val)
+            except (TypeError, ValueError):
+                continue
+            if not math.isnan(price):
+                prices[t] = price
+    else:
+        if tickers:
+            val = data["Close"].iloc[-1]
+            try:
+                price = float(val)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if not math.isnan(price):
+                    prices[tickers[0]] = price
+
     return prices
 
 

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import numpy as np
+import types
+
+import pages.watchlist as watchlist
+
+
+def _clear_cache():
+    try:
+        watchlist.load_watchlist_prices.clear()
+    except Exception:
+        pass
+
+
+def test_load_watchlist_prices_mixed_valid_invalid(monkeypatch):
+    calls = {}
+
+    def fake_fetch_prices(tickers):
+        calls["tickers"] = tickers
+        data = pd.DataFrame(
+            {
+                ("Close", "GOOD"): [101.0],
+                ("Close", "NAN"): [np.nan],
+                ("Close", "STR"): ["oops"],
+            }
+        )
+        data.columns = pd.MultiIndex.from_tuples(data.columns)
+        return data
+
+    monkeypatch.setattr(watchlist, "fetch_prices", fake_fetch_prices)
+    _clear_cache()
+    result = watchlist.load_watchlist_prices(["GOOD", "NAN", "STR", "MISS"])
+    assert calls["tickers"] == ["GOOD", "NAN", "STR", "MISS"]
+    assert result == {"GOOD": 101.0}
+    assert all(isinstance(v, float) for v in result.values())
+
+
+def test_load_watchlist_prices_empty_dataframe(monkeypatch):
+    def fake_fetch_prices(tickers):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(watchlist, "fetch_prices", fake_fetch_prices)
+    _clear_cache()
+    result = watchlist.load_watchlist_prices(["ANY"])
+    assert result == {}


### PR DESCRIPTION
## Summary
- Replace per-ticker loop with single `fetch_prices` call for watchlist data
- Convert `fetch_prices` result into `{ticker: price}` mapping while ignoring invalid values
- Add regression tests for `load_watchlist_prices` covering valid/invalid tickers and empty datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68956151697c8321845ff0139282c8e0