### PR TITLE
Refactor portfolio workflow and introduce logging

### DIFF
--- a/scripts/generate_graph.py
+++ b/scripts/generate_graph.py
@@ -6,6 +6,7 @@ is simply reorganised and commented for clarity.
 """
 
 import argparse
+import logging
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -97,15 +98,13 @@ def main(
         end_date = max_portfolio
 
     if start_date < min_portfolio:
-        print(
-            "Start date before portfolio history; using",
-            min_portfolio.date(),
+        logging.getLogger(__name__).info(
+            "Start date before portfolio history; using %s", min_portfolio.date()
         )
         start_date = min_portfolio
     if end_date > max_portfolio:
-        print(
-            "End date after portfolio history; using",
-            max_portfolio.date(),
+        logging.getLogger(__name__).info(
+            "End date after portfolio history; using %s", max_portfolio.date()
         )
         end_date = max_portfolio
     if start_date > end_date:
@@ -172,6 +171,7 @@ if __name__ == "__main__":
         help="End date for the chart (YYYY-MM-DD)",
     )
     args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
 
     start = parse_date(args.start_date, "start date") if args.start_date else None
     end = parse_date(args.end_date, "end date") if args.end_date else None

--- a/scripts/migrate_csv_to_sqlite.py
+++ b/scripts/migrate_csv_to_sqlite.py
@@ -1,4 +1,5 @@
 """Migration script to import existing CSV data into the SQLite database."""
+import logging
 import pandas as pd
 
 from config import (
@@ -59,4 +60,5 @@ def migrate() -> None:
 
 if __name__ == "__main__":
     migrate()
-    print("Migration complete.")
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger(__name__).info("Migration complete.")


### PR DESCRIPTION
## Summary
- replace debug prints with configurable logger across project
- refactor `process_portfolio` into smaller helper functions
- switch scripts to logging instead of print statements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689563f24f0c8321bde728b7059bfcde