### PR TITLE
Configure test Python path and remove path hacks

### DIFF
--- a/legacy/start_your_own/Trading_Script.py
+++ b/legacy/start_your_own/Trading_Script.py
@@ -6,10 +6,6 @@ This example script is archived and kept for reference only.
 """
 
 from pathlib import Path
-import sys
-
-# Allow importing the shared module from the repository root
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from trading_script import main
 

--- a/legacy/trading_script_wrapper.py
+++ b/legacy/trading_script_wrapper.py
@@ -4,10 +4,6 @@ This file is retained for historical reference and is no longer maintained.
 """
 
 from pathlib import Path
-import sys
-
-# Allow importing the shared module from the repository root
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from trading_script import main
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,9 +1,4 @@
-from pathlib import Path
-import sys
-
 import pandas as pd
-
-sys.path.append(str(Path(__file__).resolve().parent.parent))
 from portfolio import ensure_schema, PORTFOLIO_COLUMNS
 
 


### PR DESCRIPTION
## Summary
- configure pytest to expose project root on `PYTHONPATH`
- remove path appends from tests and legacy scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895689bab6c832196caa6c30de704e6