### PR TITLE
Remove unused PortfolioRecord dataclass

### DIFF
--- a/portfolio.py
+++ b/portfolio.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass, field
-from pathlib import Path
 from typing import List
 import pandas as pd
 
@@ -14,20 +12,6 @@ PORTFOLIO_COLUMNS: List[str] = [
     "buy_price",
     "cost_basis",
 ]
-
-
-@dataclass
-class PortfolioRecord:
-    """Dataclass representing a single portfolio holding."""
-
-    ticker: str
-    shares: float
-    stop_loss: float
-    buy_price: float
-    cost_basis: float = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.cost_basis = self.shares * self.buy_price
 
 
 def ensure_schema(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- delete unused `PortfolioRecord` dataclass from portfolio module
- tidy imports and keep schema helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689569c5e9988321ac6ca2a204d438ec