### PR TITLE
Add trace-based coverage helper and document testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ pip install -r requirements.txt
 
 Historical wrapper scripts are kept in the `legacy/` folder for reference.
 
+# Testing and Code Coverage
+
+Unit tests live in the `tests/` directory. A helper script `scripts/run_tests_with_coverage.py` runs the suite and enforces a default 95% coverage threshold.
+
+```
+python scripts/run_tests_with_coverage.py
+```
+
+To view coverage without failing on the current percentage, supply a lower minimum:
+
+```
+python scripts/run_tests_with_coverage.py --min 0
+```
+
+Additional tests should be added until the 95% requirement is met.
+
 # Follow Along
 The experiment runs June 2025 to December 2025.
 Every trading day I will update the portfolio CSV file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas==2.2.2
 yfinance==0.2.38
 matplotlib==3.8.4
 streamlit==1.36.0
+
+pytest>=8.0

--- a/scripts/run_tests_with_coverage.py
+++ b/scripts/run_tests_with_coverage.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Run unit tests and enforce a minimum coverage percentage.
+
+This script uses Python's built-in ``trace`` module to collect basic
+coverage information while executing the project's pytest suite.  It
+avoids external dependencies such as ``coverage`` or ``pytest-cov``
+which may not be available in the execution environment.
+
+The script prints a per-file summary of executed versus total lines and
+exits with a non-zero status code if the overall coverage percentage is
+below the required threshold (95% by default).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import trace
+
+import pytest
+
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def run_tests() -> trace.CoverageResults:
+    """Run pytest under ``trace`` and return coverage results."""
+    tracer = trace.Trace(
+        count=True,
+        trace=False,
+        ignoremods=("pytest",),
+        ignoredirs=[sys.prefix, sys.exec_prefix],
+    )
+    tracer.runfunc(lambda: pytest.main([]))
+    return tracer.results()
+
+
+def compute_coverage(results: trace.CoverageResults) -> tuple[dict[str, tuple[int, int]], float]:
+    """Compute executed/total line counts for project files.
+
+    Returns a mapping of filename -> (executed, total) and the overall coverage percentage.
+    """
+    files: dict[str, set[int]] = {}
+    for (filename, lineno), _ in results.counts.items():
+        if not filename.startswith(PROJECT_ROOT):
+            continue
+        if os.sep + "tests" + os.sep in filename:
+            continue
+        files.setdefault(filename, set()).add(lineno)
+
+    totals: dict[str, tuple[int, int]] = {}
+    covered = missed = 0
+    for filename, executed_lines in files.items():
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                # Count only non-empty, non-comment lines as executable.
+                lines = [l for l in f if l.strip() and not l.strip().startswith("#")]
+        except OSError:
+            continue
+        total = len(lines)
+        executed = len(executed_lines)
+        totals[filename] = (executed, total)
+        covered += executed
+        missed += total - executed
+
+    coverage_pct = 100.0 * covered / (covered + missed) if (covered + missed) else 0.0
+    return totals, coverage_pct
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--min",
+        type=float,
+        default=95.0,
+        help="minimum acceptable overall coverage percentage",
+    )
+    args = parser.parse_args()
+
+    results = run_tests()
+    totals, coverage_pct = compute_coverage(results)
+
+    for filename, (executed, total) in sorted(totals.items()):
+        rel = os.path.relpath(filename, PROJECT_ROOT)
+        print(f"{rel}: {executed}/{total}")
+    print(f"Total coverage: {coverage_pct:.2f}%")
+
+    if coverage_pct < args.min:
+        print(
+            f"Coverage {coverage_pct:.2f}% is below required {args.min}%", file=sys.stderr
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/run_tests_with_coverage.py` to measure coverage with Python's built-in trace module and enforce a 95% threshold
- document running tests and coverage requirements in README
- include pytest in requirements for consistent local testing

## Testing
- `pytest`
- `python scripts/run_tests_with_coverage.py` *(fails: Coverage 15.21% is below required 95.0%)*
- `python scripts/run_tests_with_coverage.py --min 0`


------
https://chatgpt.com/codex/tasks/task_e_68956b1bb0f4832187f1bc197f4a275b