### PR TITLE
Add ticker default to buy form and simplify watchlist import

### DIFF
--- a/pages/watchlist.py
+++ b/pages/watchlist.py
@@ -24,7 +24,7 @@ st.markdown(
 from components.nav import navbar
 from services.session import get_watchlist, add_to_watchlist, remove_from_watchlist
 from services.market import fetch_price, fetch_prices
-from ui.forms import LogABuy
+from ui.forms import show_buy_form
 
 
 @st.cache_data(ttl=1800)
@@ -124,7 +124,7 @@ def watchlist_page():
             st.rerun()
         if row_cols[4].button("Buy", key=f"buy_{ticker}"):
             with st.modal(f"Buy {ticker}"):
-                LogABuy(ticker_default=ticker)
+                show_buy_form(ticker_default=ticker)
 
 if __name__ == "__main__":
     watchlist_page()

--- a/ui/forms.py
+++ b/ui/forms.py
@@ -4,8 +4,14 @@ from config import COL_TICKER, COL_SHARES, COL_PRICE
 from services.trading import manual_buy, manual_sell
 
 
-def show_buy_form() -> None:
-    """Render and process the buy form inside an expander."""
+def show_buy_form(ticker_default: str = "") -> None:
+    """Render and process the buy form inside an expander.
+
+    Parameters
+    ----------
+    ticker_default: str, optional
+        When provided, pre-populates the ticker input with this value.
+    """
 
     def submit_buy() -> None:
         if st.session_state.b_shares <= 0 or st.session_state.b_price <= 0:
@@ -37,7 +43,12 @@ def show_buy_form() -> None:
 
     with st.expander("Log a Buy"):
         with st.form("buy_form", clear_on_submit=True):
-            st.text_input("Ticker", key="b_ticker", placeholder="e.g. AAPL")
+            st.text_input(
+                "Ticker",
+                key="b_ticker",
+                placeholder="e.g. AAPL",
+                value=ticker_default,
+            )
             st.number_input(
                 "Shares",
                 min_value=1,
@@ -152,8 +163,5 @@ def show_sell_form() -> None:
                 key="s_price",
             )
             st.form_submit_button("Submit Sell", on_click=submit_sell)
-
-
-LogABuy = show_buy_form
 
 


### PR DESCRIPTION
## Summary
- allow pre-filling ticker in `show_buy_form` via new `ticker_default` parameter
- remove `LogABuy` alias and import `show_buy_form` directly in watchlist page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895725356c88321af657ca6b9209119