### PR TITLE
Centralize watchlist helpers into service module

### DIFF
--- a/pages/watchlist.py
+++ b/pages/watchlist.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from datetime import datetime
-import math
 
 import streamlit as st
 
@@ -22,42 +21,14 @@ st.markdown(
 )
 
 from components.nav import navbar
-from services.session import get_watchlist, add_to_watchlist, remove_from_watchlist
-from services.market import fetch_price, fetch_prices
+from services.watchlist_service import (
+    get_watchlist,
+    add_to_watchlist,
+    remove_from_watchlist,
+    load_watchlist_prices,
+)
+from services.market import fetch_price
 from ui.forms import show_buy_form
-
-
-@st.cache_data(ttl=1800)
-def load_watchlist_prices(tickers: list[str]) -> dict[str, float]:
-    data = fetch_prices(tickers)
-    prices: dict[str, float] = {}
-    if data.empty:
-        return prices
-
-    if data.columns.nlevels > 1:
-        close = data["Close"].iloc[-1]
-        for t in tickers:
-            val = close.get(t)
-            if val is None:
-                continue
-            try:
-                price = float(val)
-            except (TypeError, ValueError):
-                continue
-            if not math.isnan(price):
-                prices[t] = price
-    else:
-        if tickers:
-            val = data["Close"].iloc[-1]
-            try:
-                price = float(val)
-            except (TypeError, ValueError):
-                pass
-            else:
-                if not math.isnan(price):
-                    prices[tickers[0]] = price
-
-    return prices
 
 
 def watchlist_page():

--- a/services/session.py
+++ b/services/session.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 from config import WATCHLIST_FILE
 from data.portfolio import load_portfolio
-from data.watchlist import load_watchlist, save_watchlist
+from data.watchlist import load_watchlist
 
 
 def init_session_state() -> None:
@@ -35,33 +35,3 @@ def init_session_state() -> None:
 
     if not st.session_state.watchlist and WATCHLIST_FILE.exists():
         st.session_state.watchlist = load_watchlist()
-
-
-def get_watchlist() -> list[str]:
-    """Return the current watchlist from ``st.session_state``."""
-
-    return st.session_state.get("watchlist", [])
-
-
-def add_to_watchlist(ticker: str) -> None:
-    """Add ``ticker`` to the watchlist and persist it."""
-
-    watchlist = st.session_state.setdefault("watchlist", [])
-    symbol = ticker.upper()
-    if symbol and symbol not in watchlist:
-        watchlist.append(symbol)
-        save_watchlist(watchlist)
-
-
-def remove_from_watchlist(symbol: str) -> None:
-    """Remove a ticker symbol from the watchlist in session state and persistent storage."""
-
-    # Load the current list
-    watchlist = get_watchlist()
-    # Remove if present
-    if symbol in watchlist:
-        watchlist.remove(symbol)
-        # Persist the updated list
-        save_watchlist(watchlist)
-        # Update session state if needed
-        st.session_state.watchlist = watchlist

--- a/services/watchlist_service.py
+++ b/services/watchlist_service.py
@@ -1,0 +1,66 @@
+import math
+import streamlit as st
+
+from data.watchlist import save_watchlist
+from services.market import fetch_prices
+
+
+@st.cache_data(ttl=1800)
+def load_watchlist_prices(tickers: list[str]) -> dict[str, float]:
+    """Fetch and parse latest prices for ``tickers``."""
+
+    data = fetch_prices(tickers)
+    prices: dict[str, float] = {}
+    if data.empty:
+        return prices
+
+    if data.columns.nlevels > 1:
+        close = data["Close"].iloc[-1]
+        for t in tickers:
+            val = close.get(t)
+            if val is None:
+                continue
+            try:
+                price = float(val)
+            except (TypeError, ValueError):
+                continue
+            if not math.isnan(price):
+                prices[t] = price
+    else:
+        if tickers:
+            val = data["Close"].iloc[-1]
+            try:
+                price = float(val)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if not math.isnan(price):
+                    prices[tickers[0]] = price
+
+    return prices
+
+
+def get_watchlist() -> list[str]:
+    """Return the current watchlist from ``st.session_state``."""
+
+    return st.session_state.get("watchlist", [])
+
+
+def add_to_watchlist(ticker: str) -> None:
+    """Add ``ticker`` to the watchlist and persist it."""
+
+    watchlist = st.session_state.setdefault("watchlist", [])
+    symbol = ticker.upper()
+    if symbol and symbol not in watchlist:
+        watchlist.append(symbol)
+        save_watchlist(watchlist)
+
+
+def remove_from_watchlist(symbol: str) -> None:
+    """Remove a ticker symbol from the watchlist in session state and persistent storage."""
+
+    watchlist = get_watchlist()
+    if symbol in watchlist:
+        watchlist.remove(symbol)
+        save_watchlist(watchlist)
+        st.session_state.watchlist = watchlist

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-import pages.watchlist as watchlist
+import services.watchlist_service as watchlist
 
 
 def _clear_cache():


### PR DESCRIPTION
## Summary
- Extract watchlist price loading and session helpers into `services/watchlist_service.py`
- Refactor UI and page watchlist views to use the new shared helpers
- Update tests to target the centralized watchlist API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895767aef6c8321a66c8c083b54a80d